### PR TITLE
Refactor: Non-Binding RwaTokenFactory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "lib/dss-chain-log"]
 	path = lib/dss-chain-log
 	url = https://github.com/makerdao/dss-chain-log
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/src/tokens/RwaTokenFactory.sol
+++ b/src/tokens/RwaTokenFactory.sol
@@ -31,7 +31,7 @@ contract RwaTokenFactory {
      * @param symbol Token symbol.
      * @param recipient Token address recipient.
      */
-    event RwaTokenCreated(string name, string indexed symbol, address indexed recipient);
+    event RwaTokenCreated(address indexed token, string name, string indexed symbol, address indexed recipient);
 
     /**
      * @notice Deploy an RWA Token and mint `1 * WAD` to recipient address.
@@ -51,7 +51,7 @@ contract RwaTokenFactory {
         RwaToken token = new RwaToken(name, symbol);
         token.transfer(recipient, 1 * WAD);
 
-        emit RwaTokenCreated(name, symbol, recipient);
+        emit RwaTokenCreated(address(token), name, symbol, recipient);
         return token;
     }
 }

--- a/src/tokens/RwaTokenFactory.sol
+++ b/src/tokens/RwaTokenFactory.sol
@@ -25,11 +25,6 @@ import {RwaToken} from "./RwaToken.sol";
 contract RwaTokenFactory {
     uint256 internal constant WAD = 10**18;
 
-    /// @notice registry for RWA tokens. `tokenAddresses[symbol]`
-    mapping(bytes32 => address) public tokenAddresses;
-    /// @notice list of created RWA token symbols.
-    bytes32[] public tokens;
-
     /**
      * @notice RWA Token created.
      * @param name Token name.
@@ -40,7 +35,6 @@ contract RwaTokenFactory {
 
     /**
      * @notice Deploy an RWA Token and mint `1 * WAD` to recipient address.
-     * @dev History of created tokens are stored in `tokenData` which is publicly accessible
      * @param name Token name.
      * @param symbol Token symbol.
      * @param recipient Recipient address.
@@ -50,51 +44,14 @@ contract RwaTokenFactory {
         string calldata symbol,
         address recipient
     ) public returns (RwaToken) {
-        require(recipient != address(0), "RwaTokenFactory/recipient-not-set");
         require(bytes(name).length != 0, "RwaTokenFactory/name-not-set");
         require(bytes(symbol).length != 0, "RwaTokenFactory/symbol-not-set");
-
-        bytes32 _symbol = stringToBytes32(symbol);
-        require(tokenAddresses[_symbol] == address(0), "RwaTokenFactory/symbol-already-exists");
+        require(recipient != address(0), "RwaTokenFactory/invalid-recipient");
 
         RwaToken token = new RwaToken(name, symbol);
-        tokenAddresses[_symbol] = address(token);
-        tokens.push(_symbol);
-
         token.transfer(recipient, 1 * WAD);
 
         emit RwaTokenCreated(name, symbol, recipient);
         return token;
-    }
-
-    /**
-     * @notice Gets the number of RWA Tokens created by this factory.
-     */
-    function count() external view returns (uint256) {
-        return tokens.length;
-    }
-
-    /**
-     * @notice Gets the list of symbols of all RWA Tokens created by this factory.
-     */
-    function list() external view returns (bytes32[] memory) {
-        return tokens;
-    }
-
-    /**
-     * @notice Helper function for converting string to bytes32.
-     * @dev If `source` is longer than 32 bytes (i.e.: 32 ASCII chars), then it will be truncated.
-     * @param source String to convert.
-     * @return result The numeric ASCII representation of `source`, up to 32 chars long.
-     */
-    function stringToBytes32(string calldata source) public pure returns (bytes32 result) {
-        bytes memory sourceAsBytes = bytes(source);
-        if (sourceAsBytes.length == 0) {
-            return 0x0;
-        }
-
-        assembly {
-            result := mload(add(sourceAsBytes, 32))
-        }
     }
 }

--- a/src/tokens/RwaTokenFactory.t.sol
+++ b/src/tokens/RwaTokenFactory.t.sol
@@ -16,19 +16,21 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.6.12;
 
-import {DSTest} from "ds-test/test.sol";
+import {Test} from "forge-std/Test.sol";
 import {ForwardProxy} from "forward-proxy/ForwardProxy.sol";
 
 import {RwaToken} from "./RwaToken.sol";
 import {RwaTokenFactory} from "./RwaTokenFactory.sol";
 
-contract RwaTokenFactoryTest is DSTest {
+contract RwaTokenFactoryTest is Test {
     uint256 internal constant WAD = 10**18;
 
     ForwardProxy internal recipient;
     RwaTokenFactory internal tokenFactory;
     string internal constant NAME = "RWA001-Test";
     string internal constant SYMBOL = "RWA001";
+
+    event RwaTokenCreated(address indexed token, string name, string indexed symbol, address indexed recipient);
 
     function setUp() public {
         recipient = new ForwardProxy();
@@ -47,5 +49,13 @@ contract RwaTokenFactoryTest is DSTest {
         RwaToken token = tokenFactory.createRwaToken(NAME, SYMBOL, address(recipient));
         assertTrue(address(token) != address(0));
         assertEq(token.balanceOf(address(recipient)), 1 * WAD);
+    }
+
+    function testCreateRwaTokenEmitTheProperEvent() public {
+        // `token` is the 1st topic, but we cannot check it since it will only be known after calling the method.
+        vm.expectEmit(false, true, true, true);
+        emit RwaTokenCreated(address(0), NAME, SYMBOL, address(recipient));
+
+        tokenFactory.createRwaToken(NAME, SYMBOL, address(recipient));
     }
 }

--- a/src/tokens/RwaTokenFactory.t.sol
+++ b/src/tokens/RwaTokenFactory.t.sol
@@ -25,8 +25,8 @@ import {RwaTokenFactory} from "./RwaTokenFactory.sol";
 contract RwaTokenFactoryTest is DSTest {
     uint256 internal constant WAD = 10**18;
 
-    ForwardProxy recipient;
-    RwaTokenFactory tokenFactory;
+    ForwardProxy internal recipient;
+    RwaTokenFactory internal tokenFactory;
     string internal constant NAME = "RWA001-Test";
     string internal constant SYMBOL = "RWA001";
 
@@ -35,44 +35,17 @@ contract RwaTokenFactoryTest is DSTest {
         tokenFactory = new RwaTokenFactory();
     }
 
-    function testFail_nameAndSymbolRequired() public {
+    function testFailNameAndSymbolRequired() public {
         tokenFactory.createRwaToken("", "", address(this));
     }
 
-    function testFail_recipientRequired() public {
+    function testFailRecipientRequired() public {
         tokenFactory.createRwaToken(NAME, SYMBOL, address(0));
     }
 
-    function testFail_failOnAlreadyExistSymbol() public {
-        RwaToken token = tokenFactory.createRwaToken(NAME, SYMBOL, address(recipient));
-        assertTrue(address(token) != address(0));
-        tokenFactory.createRwaToken(NAME, SYMBOL, address(recipient));
-    }
-
-    function test_canCreateRwaToken() public {
+    function testCanCreateRwaToken() public {
         RwaToken token = tokenFactory.createRwaToken(NAME, SYMBOL, address(recipient));
         assertTrue(address(token) != address(0));
         assertEq(token.balanceOf(address(recipient)), 1 * WAD);
-    }
-
-    function test_canGetRegistry() public {
-        RwaToken token = tokenFactory.createRwaToken(NAME, SYMBOL, address(recipient));
-        assertTrue(address(token) != address(0));
-        bytes32 symbol = tokenFactory.stringToBytes32(SYMBOL);
-        bytes32[1] memory tokens = [symbol];
-        bytes32[] memory tokensFromFactory = tokenFactory.list();
-        assertEq(tokenFactory.count(), tokens.length);
-        assertEq(tokensFromFactory[0], tokens[0]);
-        assertEq(tokenFactory.tokenAddresses(symbol), address(token));
-    }
-
-    function test_truncatesLargeStrings() public {
-        string memory str40Bytes = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
-        string memory str32Bytes = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
-
-        bytes32 truncated = tokenFactory.stringToBytes32(str40Bytes);
-        bytes32 notTruncated = tokenFactory.stringToBytes32(str32Bytes);
-
-        assertEq(truncated, notTruncated);
     }
 }


### PR DESCRIPTION
Previously we thought about using the `RwaTokenFactory` contract also as a registry for RWA Tokens, however we moved past that idea and now we are choosing a simpler design, closer to other factories in MCD.
