### PR TITLE
Conduits3: Resolve PE comments

### DIFF
--- a/src/conduits/RwaInputConduit3.sol
+++ b/src/conduits/RwaInputConduit3.sol
@@ -197,17 +197,17 @@ contract RwaInputConduit3 {
     //////////////////////////////////*/
 
     /**
-     * @notice Method to swap GEM contract balance to DAI through PSM and push it into RwaUrn address.
-     * @dev `msg.sender` must first receive push acess through mate().
+     * @notice Swaps the GEM balance of this contract into DAI through the PSM and push it into the `to` address.
+     * @dev `msg.sender` must have received push access through `mate()`.
      */
     function push() external isMate {
         _doPush(gem.balanceOf(address(this)));
     }
 
     /**
-     * @notice Method to swap specific amount of GEM contract balance to DAI through PSM and push it into RwaUrn address.
+     * @notice Swaps the specified amount of GEM into DAI through the PSM and push it into the `to` address.
      * @dev `msg.sender` must first receive push acess through mate().
-     * @param amt Gem amount
+     * @param amt Gem amount.
      */
     function push(uint256 amt) external isMate {
         _doPush(amt);
@@ -215,7 +215,7 @@ contract RwaInputConduit3 {
 
     /**
      * @notice Flushes out any GEM balance to `quitTo` address.
-     * @dev `msg.sender` must first receive push acess through mate().
+     * @dev `msg.sender` must have received push access through `mate()`.
      */
     function quit() external isMate {
         _doQuit(gem.balanceOf(address(this)));
@@ -223,16 +223,16 @@ contract RwaInputConduit3 {
 
     /**
      * @notice Flushes out specific amount of GEM balance to `quitTo` address.
-     * @dev `msg.sender` must first receive push acess through mate().
-     * @param amt Gem amount
+     * @dev `msg.sender` must have received push access through `mate()`.
+     * @param amt Gem amount.
      */
     function quit(uint256 amt) external isMate {
         _doQuit(amt);
     }
 
     /**
-     * @notice Internal method to swap specific amount of GEM contract balance to DAI through PSM and push it into RwaUrn address.
-     * @param amt Gem amount
+     * @notice Swaps the specified amount of GEM into DAI through the PSM and push it into the `to` address.
+     * @param amt GEM amount.
      */
     function _doPush(uint256 amt) internal {
         psm.sellGem(address(this), amt);
@@ -244,8 +244,8 @@ contract RwaInputConduit3 {
     }
 
     /**
-     * @notice Internal method wich flushes out specific amount of GEM balance to `quitTo` address.
-     * @param amt Gem amount
+     * @notice Flushes out the specified amount of GEM to the `quitTo` address.
+     * @param amt GEM amount.
      */
     function _doQuit(uint256 amt) internal {
         gem.transfer(quitTo, amt);

--- a/src/conduits/RwaInputConduit3.sol
+++ b/src/conduits/RwaInputConduit3.sol
@@ -214,6 +214,7 @@ contract RwaInputConduit3 {
     /**
      * @notice Method to swap specific amount of USDC contract balance to DAI through PSM and push it into RwaUrn address.
      * @dev `msg.sender` must first receive push acess through mate().
+     * @param amt Gem amount
      */
     function push(uint256 amt) external isMate {
         uint256 gemBalance = gem.balanceOf(address(this));
@@ -241,6 +242,7 @@ contract RwaInputConduit3 {
     /**
      * @notice Flushes out specific amount of GEM balance to `quitTo` address.
      * @dev `msg.sender` must first receive push acess through mate().
+     * @param amt Gem amount
      */
     function quit(uint256 amt) external isMate {
         uint256 gemBalance = gem.balanceOf(address(this));

--- a/src/conduits/RwaInputConduit3.sol
+++ b/src/conduits/RwaInputConduit3.sol
@@ -197,19 +197,6 @@ contract RwaInputConduit3 {
     //////////////////////////////////*/
 
     /**
-     * @notice Internal method to swap specific amount of GEM contract balance to DAI through PSM and push it into RwaUrn address.
-     * @param amt Gem amount
-     */
-    function _doPush(uint256 amt) internal {
-        psm.sellGem(address(this), amt);
-
-        uint256 daiBalance = dai.balanceOf(address(this));
-        dai.transfer(to, daiBalance);
-
-        emit Push(to, daiBalance);
-    }
-
-    /**
      * @notice Method to swap GEM contract balance to DAI through PSM and push it into RwaUrn address.
      * @dev `msg.sender` must first receive push acess through mate().
      */
@@ -227,15 +214,6 @@ contract RwaInputConduit3 {
     }
 
     /**
-     * @notice Internal method wich flushes out specific amount of GEM balance to `quitTo` address.
-     * @param amt Gem amount
-     */
-    function _doQuit(uint256 amt) internal {
-        gem.transfer(quitTo, amt);
-        emit Quit(quitTo, amt);
-    }
-
-    /**
      * @notice Flushes out any GEM balance to `quitTo` address.
      * @dev `msg.sender` must first receive push acess through mate().
      */
@@ -250,5 +228,27 @@ contract RwaInputConduit3 {
      */
     function quit(uint256 amt) external isMate {
         _doQuit(amt);
+    }
+
+    /**
+     * @notice Internal method to swap specific amount of GEM contract balance to DAI through PSM and push it into RwaUrn address.
+     * @param amt Gem amount
+     */
+    function _doPush(uint256 amt) internal {
+        psm.sellGem(address(this), amt);
+
+        uint256 daiBalance = dai.balanceOf(address(this));
+        dai.transfer(to, daiBalance);
+
+        emit Push(to, daiBalance);
+    }
+
+    /**
+     * @notice Internal method wich flushes out specific amount of GEM balance to `quitTo` address.
+     * @param amt Gem amount
+     */
+    function _doQuit(uint256 amt) internal {
+        gem.transfer(quitTo, amt);
+        emit Quit(quitTo, amt);
     }
 }

--- a/src/conduits/RwaInputConduit3.sol
+++ b/src/conduits/RwaInputConduit3.sol
@@ -1,5 +1,5 @@
-// Copyright (C) 2020, 2021 Lev Livnev <lev@liv.nev.org.uk>
-// Copyright (C) 2022 Dai Foundation
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -13,8 +13,6 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.6.12;
 
 import {DSTokenAbstract} from "dss-interfaces/dapp/DSTokenAbstract.sol";

--- a/src/conduits/RwaInputConduit3.sol
+++ b/src/conduits/RwaInputConduit3.sol
@@ -218,7 +218,7 @@ contract RwaInputConduit3 {
     }
 
     /**
-     * @notice Method to swap specific amount of USDC contract balance to DAI through PSM and push it into RwaUrn address.
+     * @notice Method to swap specific amount of GEM contract balance to DAI through PSM and push it into RwaUrn address.
      * @dev `msg.sender` must first receive push acess through mate().
      * @param amt Gem amount
      */

--- a/src/conduits/RwaInputConduit3.sol
+++ b/src/conduits/RwaInputConduit3.sol
@@ -31,7 +31,9 @@ import {GemJoinAbstract} from "dss-interfaces/dss/GemJoinAbstract.sol";
  *  - `push()` permissions are managed by `mate()`/`hate()` methods.
  *  - Require PSM address in constructor
  *  - The `push()` method swaps GEM to DAI using PSM
+ *  - THe `push()` method with `amount` argument swaps specified amount of GEM to DAI using PSM
  *  - The `quit` method allows moving outstanding GEM balance to `quitTo`. It can be called only by the admin.
+ *  - The `quit` method with `amount` argument allows moving specified amount of GEM balance to `quitTo`.
  *  - The `file` method allows updating `quitTo`, `to` addresses. It can be called only by the admin.
  */
 contract RwaInputConduit3 {
@@ -206,7 +208,7 @@ contract RwaInputConduit3 {
 
     /**
      * @notice Swaps the specified amount of GEM into DAI through the PSM and push it into the `to` address.
-     * @dev `msg.sender` must first receive push acess through mate().
+     * @dev `msg.sender` must have received push access through `mate()`.
      * @param amt Gem amount.
      */
     function push(uint256 amt) external isMate {
@@ -253,6 +255,10 @@ contract RwaInputConduit3 {
         gem.transfer(quitTo, amt);
         emit Quit(quitTo, amt);
     }
+
+    /*//////////////////////////////////
+                    Math
+    //////////////////////////////////*/
 
     function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x - y) <= x, "Math/sub-overflow");

--- a/src/conduits/RwaInputConduit3.sol
+++ b/src/conduits/RwaInputConduit3.sol
@@ -197,29 +197,10 @@ contract RwaInputConduit3 {
     //////////////////////////////////*/
 
     /**
-     * @notice Method to swap USDC contract balance to DAI through PSM and push it into RwaUrn address.
-     * @dev `msg.sender` must first receive push acess through mate().
-     */
-    function push() external isMate {
-        uint256 balance = gem.balanceOf(address(this));
-
-        psm.sellGem(address(this), balance);
-
-        uint256 daiBalance = dai.balanceOf(address(this));
-        dai.transfer(to, daiBalance);
-
-        emit Push(to, daiBalance);
-    }
-
-    /**
-     * @notice Method to swap specific amount of USDC contract balance to DAI through PSM and push it into RwaUrn address.
-     * @dev `msg.sender` must first receive push acess through mate().
+     * @notice Internal method to swap specific amount of GEM contract balance to DAI through PSM and push it into RwaUrn address.
      * @param amt Gem amount
      */
-    function push(uint256 amt) external isMate {
-        uint256 gemBalance = gem.balanceOf(address(this));
-        require(gemBalance >= amt, "RwaInputConduit3/not-enough-gems");
-
+    function _doPush(uint256 amt) internal {
         psm.sellGem(address(this), amt);
 
         uint256 daiBalance = dai.balanceOf(address(this));
@@ -229,14 +210,37 @@ contract RwaInputConduit3 {
     }
 
     /**
+     * @notice Method to swap GEM contract balance to DAI through PSM and push it into RwaUrn address.
+     * @dev `msg.sender` must first receive push acess through mate().
+     */
+    function push() external isMate {
+        _doPush(gem.balanceOf(address(this)));
+    }
+
+    /**
+     * @notice Method to swap specific amount of USDC contract balance to DAI through PSM and push it into RwaUrn address.
+     * @dev `msg.sender` must first receive push acess through mate().
+     * @param amt Gem amount
+     */
+    function push(uint256 amt) external isMate {
+        _doPush(amt);
+    }
+
+    /**
+     * @notice Internal method wich flushes out specific amount of GEM balance to `quitTo` address.
+     * @param amt Gem amount
+     */
+    function _doQuit(uint256 amt) internal {
+        gem.transfer(quitTo, amt);
+        emit Quit(quitTo, amt);
+    }
+
+    /**
      * @notice Flushes out any GEM balance to `quitTo` address.
      * @dev `msg.sender` must first receive push acess through mate().
      */
     function quit() external isMate {
-        uint256 gemBalance = gem.balanceOf(address(this));
-
-        gem.transfer(quitTo, gemBalance);
-        emit Quit(quitTo, gemBalance);
+        _doQuit(gem.balanceOf(address(this)));
     }
 
     /**
@@ -245,10 +249,6 @@ contract RwaInputConduit3 {
      * @param amt Gem amount
      */
     function quit(uint256 amt) external isMate {
-        uint256 gemBalance = gem.balanceOf(address(this));
-        require(gemBalance >= amt, "RwaInputConduit3/not-enough-gems");
-
-        gem.transfer(quitTo, amt);
-        emit Quit(quitTo, amt);
+        _doQuit(amt);
     }
 }

--- a/src/conduits/RwaInputConduit3.sol
+++ b/src/conduits/RwaInputConduit3.sol
@@ -203,7 +203,7 @@ contract RwaInputConduit3 {
     function push() external isMate {
         uint256 balance = gem.balanceOf(address(this));
 
-        psm.sellGem(address(this), balance); // can fail because of autoline
+        psm.sellGem(address(this), balance);
 
         uint256 daiBalance = dai.balanceOf(address(this));
         dai.transfer(to, daiBalance);

--- a/src/conduits/RwaInputConduit3.t.sol
+++ b/src/conduits/RwaInputConduit3.t.sol
@@ -1,9 +1,5 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
 // SPDX-License-Identifier: AGPL-3.0-or-later
-//
-// RwaUrn.t.sol -- Tests for the Urn contract
-//
-// Copyright (C) 2020-2021 Lev Livnev <lev@liv.nev.org.uk>
-// Copyright (C) 2021-2022 Dai Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -258,7 +254,7 @@ contract RwaInputConduit3Test is Test, DSMath {
         assertEq(testUrn.balance(address(dai)), 500 ether);
     }
 
-    function testPushAmountWhenHaveSomeDaiBalanceGetExectAmount() public {
+    function testPushAmountWhenHaveSomeDaiBalanceGetExactAmount() public {
         dai.mint(address(inputConduit), 100 ether);
         assertEq(dai.balanceOf(address(inputConduit)), 100 ether);
 

--- a/src/conduits/RwaInputConduit3.t.sol
+++ b/src/conduits/RwaInputConduit3.t.sol
@@ -266,7 +266,7 @@ contract RwaInputConduit3Test is Test, DSMath {
         uint256 usdxCBalanceBefore = usdx.balanceOf(address(inputConduit));
         uint256 urnDaiBalanceBefore = usdx.balanceOf(address(testUrn));
 
-        vm.assume(amt <= usdxCBalanceBefore);
+        amt = bound(amt, 1 * USDX_BASE_UNIT, usdxCBalanceBefore);
 
         vm.expectEmit(true, true, false, false);
         emit Push(address(testUrn), amt * USDX_DAI_DIF_DECIMALS);
@@ -321,14 +321,13 @@ contract RwaInputConduit3Test is Test, DSMath {
     }
 
     function testQuitAmountFuzz(uint256 amt) public {
+        assertEq(inputConduit.quitTo(), me);
         uint256 usdxBalance = usdx.balanceOf(me);
         usdx.transfer(address(inputConduit), usdxBalance);
         uint256 usdxCBalance = usdx.balanceOf(address(inputConduit));
         assertEq(usdx.balanceOf(me), 0);
 
-        vm.assume(amt <= usdxCBalance);
-
-        assertEq(inputConduit.quitTo(), me);
+        amt = bound(amt, 1 * USDX_BASE_UNIT, usdxCBalance);
 
         vm.expectEmit(true, true, false, false);
         emit Quit(inputConduit.quitTo(), amt);

--- a/src/conduits/RwaInputConduit3.t.sol
+++ b/src/conduits/RwaInputConduit3.t.sol
@@ -37,7 +37,7 @@ import {AuthGemJoin5} from "dss-psm/join-5-auth.sol";
 contract RwaInputConduit3Test is Test, DSMath {
     address me;
 
-    TestVat vat;
+    Vat vat;
     Spotter spot;
     TestVow vow;
     DSValue pip;
@@ -76,7 +76,7 @@ contract RwaInputConduit3Test is Test, DSMath {
     function setUpMCDandPSM() internal {
         me = address(this);
 
-        vat = new TestVat();
+        vat = new Vat();
         vat = vat;
 
         spot = new Spotter(address(vat));
@@ -394,12 +394,6 @@ contract RwaInputConduit3Test is Test, DSMath {
 contract TestToken is DSToken {
     constructor(string memory symbol_, uint8 decimals_) public DSToken(symbol_) {
         decimals = decimals_;
-    }
-}
-
-contract TestVat is Vat {
-    function mint(address usr, uint256 rad) public {
-        dai[usr] += rad;
     }
 }
 

--- a/src/conduits/RwaInputConduit3.t.sol
+++ b/src/conduits/RwaInputConduit3.t.sol
@@ -279,7 +279,7 @@ contract RwaInputConduit3Test is Test, DSMath {
     function testRevertOnPushAmountMoreThenGemBalance() public {
         assertEq(usdx.balanceOf(address(inputConduit)), 0);
 
-        vm.expectRevert("RwaInputConduit3/not-enough-gems");
+        vm.expectRevert("ds-token-insufficient-balance");
         inputConduit.push(1);
     }
 
@@ -340,7 +340,7 @@ contract RwaInputConduit3Test is Test, DSMath {
     function testRevertOnQuitAmountMoreThenGemBalance() public {
         assertEq(usdx.balanceOf(address(inputConduit)), 0);
 
-        vm.expectRevert("RwaInputConduit3/not-enough-gems");
+        vm.expectRevert("ds-token-insufficient-balance");
         inputConduit.quit(1);
     }
 }

--- a/src/conduits/RwaInputConduit3.t.sol
+++ b/src/conduits/RwaInputConduit3.t.sol
@@ -258,6 +258,56 @@ contract RwaInputConduit3Test is Test, DSMath {
         assertEq(testUrn.balance(address(dai)), 500 ether);
     }
 
+    function testPushAmountWhenHaveSomeDaiBalanceGetExectAmount() public {
+        dai.mint(address(inputConduit), 100 ether);
+        assertEq(dai.balanceOf(address(inputConduit)), 100 ether);
+
+        assertEq(usdx.balanceOf(me), USDX_MINT_AMOUNT);
+        assertEq(usdx.balanceOf(address(inputConduit)), 0);
+        assertEq(usdx.balanceOf(address(joinA)), 0);
+
+        usdx.transfer(address(inputConduit), 500 * USDX_BASE_UNIT);
+
+        assertEq(usdx.balanceOf(me), USDX_MINT_AMOUNT - 500 * USDX_BASE_UNIT);
+        assertEq(usdx.balanceOf(address(inputConduit)), 500 * USDX_BASE_UNIT);
+
+        assertEq(testUrn.balance(address(dai)), 0);
+
+        vm.expectEmit(true, true, false, false);
+        emit Push(address(testUrn), 500 ether);
+        inputConduit.push(500 * USDX_BASE_UNIT);
+
+        assertEq(usdx.balanceOf(address(joinA)), 500 * USDX_BASE_UNIT);
+        assertEq(usdx.balanceOf(address(inputConduit)), 0);
+        assertEq(testUrn.balance(address(dai)), 500 ether);
+        assertEq(dai.balanceOf(address(inputConduit)), 100 ether);
+    }
+
+    function testPushAmountWhenHaveSomeDaiBalanceGetAll() public {
+        dai.mint(address(inputConduit), 100 ether);
+        assertEq(dai.balanceOf(address(inputConduit)), 100 ether);
+
+        assertEq(usdx.balanceOf(me), USDX_MINT_AMOUNT);
+        assertEq(usdx.balanceOf(address(inputConduit)), 0);
+        assertEq(usdx.balanceOf(address(joinA)), 0);
+
+        usdx.transfer(address(inputConduit), 500 * USDX_BASE_UNIT);
+
+        assertEq(usdx.balanceOf(me), USDX_MINT_AMOUNT - 500 * USDX_BASE_UNIT);
+        assertEq(usdx.balanceOf(address(inputConduit)), 500 * USDX_BASE_UNIT);
+
+        assertEq(testUrn.balance(address(dai)), 0);
+
+        vm.expectEmit(true, true, false, false);
+        emit Push(address(testUrn), 500 ether);
+        inputConduit.push();
+
+        assertEq(usdx.balanceOf(address(joinA)), 500 * USDX_BASE_UNIT);
+        assertEq(usdx.balanceOf(address(inputConduit)), 0);
+        assertEq(testUrn.balance(address(dai)), 600 ether);
+        assertEq(dai.balanceOf(address(inputConduit)), 0);
+    }
+
     function testPushAmountFuzz(uint256 amt) public {
         uint256 usdxBalanceBefore = usdx.balanceOf(me);
         usdx.transfer(address(inputConduit), usdxBalanceBefore);

--- a/src/conduits/RwaOutputConduit3.sol
+++ b/src/conduits/RwaOutputConduit3.sol
@@ -274,6 +274,40 @@ contract RwaOutputConduit3 {
     //////////////////////////////////*/
 
     /**
+     * @notice Method to swap DAI contract balance to GEM through PSM and push it to the recipient address.
+     * @dev `msg.sender` must have been `mate`d and `to` must be setted.
+     */
+    function push() external isMate {
+        _doPush(dai.balanceOf(address(this)), 0);
+    }
+
+    /**
+     * @notice Method to swap specific amount of DAI contract balance to GEM through PSM and push it to the recipient address.
+     * @dev `msg.sender` must have been `mate`d and `to` must be setted.
+     * @param wad Dai amount
+     */
+    function push(uint256 wad) external isMate {
+        _doPush(wad, gem.balanceOf(address(this)));
+    }
+
+    /**
+     * @notice Flushes out any DAI balance to `quitTo` address.
+     * @dev `msg.sender` must first receive push acess through mate().
+     */
+    function quit() external isMate {
+        _doQuit(dai.balanceOf(address(this)));
+    }
+
+    /**
+     * @notice Flushes out specific amount of DAI balance to `quitTo` address.
+     * @dev `msg.sender` must first receive push acess through mate().
+     * @param wad Dai amount
+     */
+    function quit(uint256 wad) external isMate {
+        _doQuit(wad);
+    }
+
+    /**
      * @notice Internal method to swap specific amount of DAI contract balance to GEM through PSM and push it to the recipient address.
      * @param wad Dai amount
      * @param prevGemBalance Previouse GEM balance used to track exect maount of GEM swapped for DAI from PSM (Set 0 if you want to get all outstanding GEM balance)
@@ -298,44 +332,10 @@ contract RwaOutputConduit3 {
     }
 
     /**
-     * @notice Method to swap DAI contract balance to GEM through PSM and push it to the recipient address.
-     * @dev `msg.sender` must have been `mate`d and `to` must be setted.
-     */
-    function push() external isMate {
-        _doPush(dai.balanceOf(address(this)), 0);
-    }
-
-    /**
-     * @notice Method to swap specific amount of DAI contract balance to GEM through PSM and push it to the recipient address.
-     * @dev `msg.sender` must have been `mate`d and `to` must be setted.
-     * @param wad Dai amount
-     */
-    function push(uint256 wad) external isMate {
-        _doPush(wad, gem.balanceOf(address(this)));
-    }
-
-    /**
      * @notice Internal method which flushes out a specific DAI balance to `quitTo` address.
      */
     function _doQuit(uint256 wad) internal {
         dai.transfer(quitTo, wad);
         emit Quit(quitTo, wad);
-    }
-
-    /**
-     * @notice Flushes out any DAI balance to `quitTo` address.
-     * @dev `msg.sender` must first receive push acess through mate().
-     */
-    function quit() external isMate {
-        _doQuit(dai.balanceOf(address(this)));
-    }
-
-    /**
-     * @notice Flushes out specific amount of DAI balance to `quitTo` address.
-     * @dev `msg.sender` must first receive push acess through mate().
-     * @param wad Dai amount
-     */
-    function quit(uint256 wad) external isMate {
-        _doQuit(wad);
     }
 }

--- a/src/conduits/RwaOutputConduit3.sol
+++ b/src/conduits/RwaOutputConduit3.sol
@@ -33,7 +33,9 @@ import {GemJoinAbstract} from "dss-interfaces/dss/GemJoinAbstract.sol";
  *  - Requires a PSM address in the constructor.
  *  - `pick` can be called to set the `to` address. Eligible `to` addresses should be whitelisted by an admin through `kiss`.
  *  - The `push()` method swaps DAI to GEM using PSM and set `to` to zero address.
+ *  - The `push()` method with `amount` argument swaps specified amount of DAI to GEM using PSM and set `to` to zero address.
  *  - The `quit` method allows moving outstanding DAI balance to `quitTo`. It can be called only by `mate`d addresses.
+ *  - The `quit` method with `amount` argument allows moving specified amount of DAI balance to `quitTo`
  *  - The `file` method allows updating `quitTo` addresses. It can be called only by the admin.
  */
 contract RwaOutputConduit3 {
@@ -56,7 +58,7 @@ contract RwaOutputConduit3 {
     /// @notice Dai output address
     address public to;
 
-    /// @dev Whitelist for addresses which can be picked. `bud[who]`
+    /// @notice Whitelist for addresses which can be picked. `bud[who]`
     mapping(address => uint256) public bud;
     /// @notice Addresses with push access on this contract. `may[usr]`
     mapping(address => uint256) public may;
@@ -340,6 +342,10 @@ contract RwaOutputConduit3 {
         dai.transfer(quitTo, wad);
         emit Quit(quitTo, wad);
     }
+
+    /*//////////////////////////////////
+                    Math
+    //////////////////////////////////*/
 
     function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
         require((z = x - y) <= x, "Math/sub-overflow");

--- a/src/conduits/RwaOutputConduit3.sol
+++ b/src/conduits/RwaOutputConduit3.sol
@@ -1,5 +1,5 @@
-// Copyright (C) 2020, 2021 Lev Livnev <lev@liv.nev.org.uk>
-// Copyright (C) 2022 Dai Foundation
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -13,8 +13,6 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.6.12;
 
 import {DSTokenAbstract} from "dss-interfaces/dapp/DSTokenAbstract.sol";
@@ -55,7 +53,7 @@ contract RwaOutputConduit3 {
     DSTokenAbstract private __unused_gov;
     /// @notice Dai token contract address
     DSTokenAbstract public dai;
-    /// @notice Dai output address
+    /// @notice Dai Recipient address.
     address public to;
 
     /// @notice Whitelist for addresses which can be picked. `bud[who]`

--- a/src/conduits/RwaOutputConduit3.sol
+++ b/src/conduits/RwaOutputConduit3.sol
@@ -300,7 +300,7 @@ contract RwaOutputConduit3 {
     }
 
     /**
-     * @notice Flushes out specific amount of DAI balance to `quitTo` address.
+     * @notice Flushes out the specified amount of DAI to the `quitTo` address.
      * @dev `msg.sender` must have received push access through `mate()`.
      * @param wad DAI amount.
      */

--- a/src/conduits/RwaOutputConduit3.t.sol
+++ b/src/conduits/RwaOutputConduit3.t.sol
@@ -290,6 +290,29 @@ contract RwaOutputConduit3Test is Test, DSMath {
         assertEq(outputConduit.to(), address(0));
     }
 
+    function testPushAmountWhenAlreadyHaveSomeGemBalance() public {
+        usdx.mint(100 * USDX_BASE_UNIT);
+        usdx.transfer(address(outputConduit), 100 * USDX_BASE_UNIT);
+
+        assertEq(outputConduit.to(), me);
+        assertEq(usdx.balanceOf(me), 0);
+        assertEq(usdx.balanceOf(address(outputConduit)), 100 * USDX_BASE_UNIT);
+        assertEq(dai.balanceOf(address(me)), 1000 ether);
+
+        dai.transfer(address(outputConduit), 500 ether);
+
+        assertEq(dai.balanceOf(me), 500 ether);
+        assertEq(dai.balanceOf(address(outputConduit)), 500 ether);
+
+        vm.expectEmit(true, true, false, false);
+        emit Push(address(me), 500 * USDX_BASE_UNIT);
+        outputConduit.push(500 ether);
+
+        assertEq(usdx.balanceOf(address(me)), 500 * USDX_BASE_UNIT);
+        assertEq(usdx.balanceOf(address(outputConduit)), 100 * USDX_BASE_UNIT);
+        assertEq(outputConduit.to(), address(0));
+    }
+
     function testPushAmountFuzz(uint256 wad) public {
         assertEq(outputConduit.to(), me);
         dai.transfer(address(outputConduit), dai.balanceOf(me));

--- a/src/conduits/RwaOutputConduit3.t.sol
+++ b/src/conduits/RwaOutputConduit3.t.sol
@@ -386,11 +386,11 @@ contract RwaOutputConduit3Test is Test, DSMath {
 
         assertEq(dai.balanceOf(address(outputConduit)), 1100 ether);
 
-        vat.mint(address(daiJoin), 1100 ether * 10**27);
+        vat.mint(address(daiJoin), rad(1100 ether));
 
         vm.expectRevert();
         // It will revert on vat.frob()
-        // urn.ink = _add(urn.ink, dink); // _add method will revert with empty message because ink = 1000 and dink = 1100
+        // urn.ink = _add(urn.ink, dink); // _add method will revert with empty message because ink = 1000 and dink = -1100
         outputConduit.push();
 
         assertEq(dai.balanceOf(address(outputConduit)), 1100 ether);

--- a/src/conduits/RwaOutputConduit3.t.sol
+++ b/src/conduits/RwaOutputConduit3.t.sol
@@ -1,9 +1,5 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
 // SPDX-License-Identifier: AGPL-3.0-or-later
-//
-// RwaUrn.t.sol -- Tests for the Urn contract
-//
-// Copyright (C) 2020-2021 Lev Livnev <lev@liv.nev.org.uk>
-// Copyright (C) 2021-2022 Dai Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -290,7 +286,7 @@ contract RwaOutputConduit3Test is Test, DSMath {
         assertEq(outputConduit.to(), address(0));
     }
 
-    function testPushAmountWhenAlreadyHaveSomeGemBalanceGetExectAmount() public {
+    function testPushAmountWhenAlreadyHaveSomeGemBalanceGetExactAmount() public {
         usdx.mint(100 * USDX_BASE_UNIT);
         usdx.transfer(address(outputConduit), 100 * USDX_BASE_UNIT);
 

--- a/src/conduits/RwaOutputConduit3.t.sol
+++ b/src/conduits/RwaOutputConduit3.t.sol
@@ -290,7 +290,7 @@ contract RwaOutputConduit3Test is Test, DSMath {
         assertEq(outputConduit.to(), address(0));
     }
 
-    function testPushAmountWhenAlreadyHaveSomeGemBalance() public {
+    function testPushAmountWhenAlreadyHaveSomeGemBalanceGetExectAmount() public {
         usdx.mint(100 * USDX_BASE_UNIT);
         usdx.transfer(address(outputConduit), 100 * USDX_BASE_UNIT);
 
@@ -310,6 +310,29 @@ contract RwaOutputConduit3Test is Test, DSMath {
 
         assertEq(usdx.balanceOf(address(me)), 500 * USDX_BASE_UNIT);
         assertEq(usdx.balanceOf(address(outputConduit)), 100 * USDX_BASE_UNIT);
+        assertEq(outputConduit.to(), address(0));
+    }
+
+    function testPushAmountWhenAlreadyHaveSomeGemBalanceGetAll() public {
+        usdx.mint(100 * USDX_BASE_UNIT);
+        usdx.transfer(address(outputConduit), 100 * USDX_BASE_UNIT);
+
+        assertEq(outputConduit.to(), me);
+        assertEq(usdx.balanceOf(me), 0);
+        assertEq(usdx.balanceOf(address(outputConduit)), 100 * USDX_BASE_UNIT);
+        assertEq(dai.balanceOf(address(me)), 1000 ether);
+
+        dai.transfer(address(outputConduit), 500 ether);
+
+        assertEq(dai.balanceOf(me), 500 ether);
+        assertEq(dai.balanceOf(address(outputConduit)), 500 ether);
+
+        vm.expectEmit(true, true, false, false);
+        emit Push(address(me), 500 * USDX_BASE_UNIT);
+        outputConduit.push();
+
+        assertEq(usdx.balanceOf(address(me)), 600 * USDX_BASE_UNIT);
+        assertEq(usdx.balanceOf(address(outputConduit)), 0);
         assertEq(outputConduit.to(), address(0));
     }
 


### PR DESCRIPTION
[sc-1011]
- Add `amount` arg to `push` and `quit` methods of both conduits

# OutputConduit3

- Add `pick` method to pick the `to` address
- Add `kiss() / diss()` methods for managing addresses 
- Set `to` address to 0 after `push`