### PR TITLE
Refactor: Conduit Permissions

### DIFF
--- a/src/conduits/RwaInputConduit2.sol
+++ b/src/conduits/RwaInputConduit2.sol
@@ -25,7 +25,6 @@ import {DSTokenAbstract} from "dss-interfaces/dapp/DSTokenAbstract.sol";
  * @author Henrique Barcelos <henrique@clio.finance>
  * @title An Input Conduit for real-world assets (RWA).
  * @dev This contract differs from the original [RwaInputConduit](https://github.com/makerdao/MIP21-RWA-Example/blob/fce06885ff89d10bf630710d4f6089c5bba94b4d/src/RwaConduit.sol#L20-L39):
- *  - `auth`ed methods can be made permissionless by calling `rely(address(0))`.
  *  - The caller of `push()` is not required to hold MakerDAO governance tokens.
  *  - The `push()` method is permissioned.
  *  - `push()` permissions are managed by `mate()`/`hate()` methods.
@@ -90,7 +89,7 @@ contract RwaInputConduit2 {
     }
 
     modifier auth() {
-        require(wards[msg.sender] == 1 || wards[address(0)] == 1, "RwaInputConduit2/not-authorized");
+        require(wards[msg.sender] == 1, "RwaInputConduit2/not-authorized");
         _;
     }
 

--- a/src/conduits/RwaInputConduit2.t.sol
+++ b/src/conduits/RwaInputConduit2.t.sol
@@ -70,23 +70,6 @@ contract RwaInputConduit2Test is Test, DSMath {
         inputConduit.deny(address(1));
 
         assertEq(inputConduit.wards(address(1)), 0);
-
-        // Test make it permissionless
-        // --------------------
-        vm.expectEmit(true, false, false, false);
-        emit Rely(address(0));
-
-        inputConduit.rely(address(0));
-
-        assertEq(inputConduit.wards(address(0)), 1);
-
-        // --------------------
-        vm.expectEmit(true, false, false, false);
-        emit Deny(address(0));
-
-        inputConduit.deny(address(0));
-
-        assertEq(inputConduit.wards(address(0)), 0);
     }
 
     function testMateHate() public {
@@ -153,27 +136,6 @@ contract RwaInputConduit2Test is Test, DSMath {
         inputConduit.push();
     }
 
-    function testFuzzMakeMethodsPermissionless(address sender) public {
-        vm.assume(sender != address(0));
-
-        inputConduit.rely(address(0));
-        inputConduit.may(address(0));
-
-        vm.startPrank(sender);
-
-        inputConduit.rely(sender);
-        assertEq(inputConduit.wards(sender), 1);
-
-        inputConduit.mate(sender);
-        assertEq(inputConduit.may(sender), 1);
-
-        inputConduit.hate(sender);
-        assertEq(inputConduit.may(sender), 0);
-
-        inputConduit.deny(sender);
-        assertEq(inputConduit.wards(sender), 0);
-    }
-
     function testFileTo() public {
         address updatedTo = vm.addr(2);
         vm.expectEmit(true, true, false, false);
@@ -206,6 +168,7 @@ contract RwaInputConduit2Test is Test, DSMath {
 
     function testFuzzPermissionlessPush(address sender) public {
         vm.assume(sender != me);
+        inputConduit.mate(address(0));
 
         dai.mint(me, 1_000 * WAD);
 
@@ -216,8 +179,6 @@ contract RwaInputConduit2Test is Test, DSMath {
 
         assertEq(dai.balanceOf(me), 500 * WAD);
         assertEq(dai.balanceOf(address(inputConduit)), 500 * WAD);
-
-        inputConduit.mate(address(0));
 
         vm.expectEmit(true, false, false, true);
         emit Push(to, 500 * WAD);

--- a/src/conduits/RwaInputConduit2.t.sol
+++ b/src/conduits/RwaInputConduit2.t.sol
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.6.12;
+
+import "forge-std/Test.sol";
+import "ds-token/token.sol";
+import "ds-math/math.sol";
+import "ds-value/value.sol";
+
+import {Vat} from "dss/vat.sol";
+import {Jug} from "dss/jug.sol";
+import {Spotter} from "dss/spot.sol";
+import {Vow} from "dss/vow.sol";
+import {GemJoin, DaiJoin} from "dss/join.sol";
+import {Dai} from "dss/dai.sol";
+
+import {RwaInputConduit2} from "./RwaInputConduit2.sol";
+
+contract RwaInputConduit2Test is Test, DSMath {
+    address me = address(this);
+    address to = address(0x1337);
+
+    Dai dai = new Dai(0);
+    RwaInputConduit2 inputConduit = new RwaInputConduit2(address(dai), to);
+
+    function setUp() public {
+        inputConduit.mate(me);
+        inputConduit.may(me);
+    }
+
+    function testSetWardAndEmitRelyOnDeploy() public {
+        vm.expectEmit(true, false, false, false);
+        emit Rely(me);
+
+        RwaInputConduit2 c = new RwaInputConduit2(address(dai), to);
+
+        assertEq(c.wards(me), 1);
+    }
+
+    function testRelyDeny() public {
+        assertEq(inputConduit.wards(address(1)), 0);
+
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Rely(address(1));
+
+        inputConduit.rely(address(1));
+
+        assertEq(inputConduit.wards(address(1)), 1);
+
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Deny(address(1));
+
+        inputConduit.deny(address(1));
+
+        assertEq(inputConduit.wards(address(1)), 0);
+
+        // Test make it permissionless
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Rely(address(0));
+
+        inputConduit.rely(address(0));
+
+        assertEq(inputConduit.wards(address(0)), 1);
+
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Deny(address(0));
+
+        inputConduit.deny(address(0));
+
+        assertEq(inputConduit.wards(address(0)), 0);
+    }
+
+    function testMateHate() public {
+        assertEq(inputConduit.may(address(1)), 0);
+
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Mate(address(1));
+
+        inputConduit.mate(address(1));
+
+        assertEq(inputConduit.may(address(1)), 1);
+
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Hate(address(1));
+
+        inputConduit.hate(address(1));
+
+        assertEq(inputConduit.may(address(1)), 0);
+
+        assertEq(inputConduit.may(address(1)), 0);
+
+        // Test make it permissionless
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Mate(address(0));
+
+        inputConduit.mate(address(0));
+
+        assertEq(inputConduit.may(address(0)), 1);
+
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Hate(address(0));
+
+        inputConduit.hate(address(0));
+
+        assertEq(inputConduit.may(address(0)), 0);
+    }
+
+    function testFuzzRevertOnUnauthorizedMethods(address sender) public {
+        vm.assume(sender != me);
+
+        vm.startPrank(sender);
+
+        vm.expectRevert("RwaInputConduit2/not-authorized");
+        inputConduit.rely(sender);
+
+        vm.expectRevert("RwaInputConduit2/not-authorized");
+        inputConduit.deny(sender);
+
+        vm.expectRevert("RwaInputConduit2/not-authorized");
+        inputConduit.hate(sender);
+
+        vm.expectRevert("RwaInputConduit2/not-authorized");
+        inputConduit.mate(sender);
+    }
+
+    function testFuzzRevertOnNotMateMethods(address sender) public {
+        vm.expectRevert("RwaInputConduit2/not-mate");
+
+        vm.prank(sender);
+        inputConduit.push();
+    }
+
+    function testFuzzMakeMethodsPermissionless(address sender) public {
+        vm.assume(sender != address(0));
+
+        inputConduit.rely(address(0));
+        inputConduit.may(address(0));
+
+        vm.startPrank(sender);
+
+        inputConduit.rely(sender);
+        assertEq(inputConduit.wards(sender), 1);
+
+        inputConduit.mate(sender);
+        assertEq(inputConduit.may(sender), 1);
+
+        inputConduit.hate(sender);
+        assertEq(inputConduit.may(sender), 0);
+
+        inputConduit.deny(sender);
+        assertEq(inputConduit.wards(sender), 0);
+    }
+
+    function testFileTo() public {
+        address updatedTo = vm.addr(2);
+        vm.expectEmit(true, true, false, false);
+        emit File(bytes32("to"), updatedTo);
+
+        inputConduit.file(bytes32("to"), updatedTo);
+
+        assertEq(inputConduit.to(), updatedTo);
+    }
+
+    function testPush() public {
+        dai.mint(me, 1_000 * WAD);
+
+        assertEq(inputConduit.to(), to);
+        assertEq(dai.balanceOf(address(me)), 1_000 * WAD);
+
+        dai.transfer(address(inputConduit), 500 * WAD);
+
+        assertEq(dai.balanceOf(me), 500 * WAD);
+        assertEq(dai.balanceOf(address(inputConduit)), 500 * WAD);
+
+        vm.expectEmit(true, false, false, true);
+        emit Push(to, 500 * WAD);
+
+        inputConduit.push();
+
+        assertEq(dai.balanceOf(address(inputConduit)), 0);
+        assertEq(dai.balanceOf(to), 500 * WAD);
+    }
+
+    function testFuzzPermissionlessPush(address sender) public {
+        vm.assume(sender != me);
+
+        dai.mint(me, 1_000 * WAD);
+
+        assertEq(inputConduit.to(), to);
+        assertEq(dai.balanceOf(address(me)), 1_000 * WAD);
+
+        dai.transfer(address(inputConduit), 500 * WAD);
+
+        assertEq(dai.balanceOf(me), 500 * WAD);
+        assertEq(dai.balanceOf(address(inputConduit)), 500 * WAD);
+
+        inputConduit.mate(address(0));
+
+        vm.expectEmit(true, false, false, true);
+        emit Push(to, 500 * WAD);
+
+        vm.prank(sender);
+        inputConduit.push();
+
+        assertEq(dai.balanceOf(address(inputConduit)), 0);
+        assertEq(dai.balanceOf(to), 500 * WAD);
+    }
+
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+    event Mate(address indexed usr);
+    event Hate(address indexed usr);
+    event File(bytes32 indexed what, address data);
+    event Push(address indexed to, uint256 wad);
+}

--- a/src/conduits/RwaInputConduit3.sol
+++ b/src/conduits/RwaInputConduit3.sol
@@ -26,22 +26,24 @@ import {GemJoinAbstract} from "dss-interfaces/dss/GemJoinAbstract.sol";
  * @author Nazar Duchak <nazar@clio.finance>
  * @title An Input Conduit for real-world assets (RWA).
  * @dev This contract differs from the original [RwaInputConduit](https://github.com/makerdao/MIP21-RWA-Example/blob/fce06885ff89d10bf630710d4f6089c5bba94b4d/src/RwaConduit.sol#L20-L39):
+ *  - `auth`ed methods can be made permissionless by calling `rely(address(0))`.
  *  - The caller of `push()` is not required to hold MakerDAO governance tokens.
  *  - The `push()` method is permissioned.
  *  - `push()` permissions are managed by `mate()`/`hate()` methods.
- *  - Requires DAI, GEM and PSM addresses in the constructor.
- *      - DAI and GEM are immutable, PSM can be replaced as long as it uses the same DAI and GEM.
+ *  - `push()` can be made permissionless by calling `mate(address(0))`.
  *  - The `push()` method swaps entire GEM balance to DAI using PSM.
  *  - THe `push(uint256)` method swaps specified amount of GEM to DAI using PSM.
+ *  - Requires DAI, GEM and PSM addresses in the constructor.
+ *      - DAI and GEM are immutable, PSM can be replaced as long as it uses the same DAI and GEM.
  *  - The `quit()` method allows moving outstanding GEM balance to `quitTo`. It can be called only by `mate`d addresses.
  *  - The `quit(uint256)` method allows moving the specified amount of GEM balance to `quitTo`. It can be called only by `mate`d addresses.
  *  - The `file(bytes32, address)` method allows updating `quitTo`, `to`, `psm` addresses. It can be called only by the admin.
  */
 contract RwaInputConduit3 {
-    /// @notice PSM GEM token contract address.
-    GemAbstract public immutable gem;
     /// @notice DAI token contract address.
     DaiAbstract public immutable dai;
+    /// @notice PSM GEM token contract address.
+    GemAbstract public immutable gem;
     /// @dev DAI/GEM resolution difference.
     uint256 private immutable to18ConversionFactor;
 
@@ -104,12 +106,12 @@ contract RwaInputConduit3 {
     event Yank(address indexed token, address indexed usr, uint256 amt);
 
     modifier auth() {
-        require(wards[msg.sender] == 1, "RwaInputConduit3/not-authorized");
+        require(wards[msg.sender] == 1 || wards[address(0)] == 1, "RwaInputConduit3/not-authorized");
         _;
     }
 
     modifier onlyMate() {
-        require(may[msg.sender] == 1, "RwaInputConduit3/not-mate");
+        require(may[msg.sender] == 1 || may[address(0)] == 1, "RwaInputConduit3/not-mate");
         _;
     }
 

--- a/src/conduits/RwaInputConduit3.sol
+++ b/src/conduits/RwaInputConduit3.sol
@@ -26,7 +26,6 @@ import {GemJoinAbstract} from "dss-interfaces/dss/GemJoinAbstract.sol";
  * @author Nazar Duchak <nazar@clio.finance>
  * @title An Input Conduit for real-world assets (RWA).
  * @dev This contract differs from the original [RwaInputConduit](https://github.com/makerdao/MIP21-RWA-Example/blob/fce06885ff89d10bf630710d4f6089c5bba94b4d/src/RwaConduit.sol#L20-L39):
- *  - `auth`ed methods can be made permissionless by calling `rely(address(0))`.
  *  - The caller of `push()` is not required to hold MakerDAO governance tokens.
  *  - The `push()` method is permissioned.
  *  - `push()` permissions are managed by `mate()`/`hate()` methods.
@@ -106,7 +105,7 @@ contract RwaInputConduit3 {
     event Yank(address indexed token, address indexed usr, uint256 amt);
 
     modifier auth() {
-        require(wards[msg.sender] == 1 || wards[address(0)] == 1, "RwaInputConduit3/not-authorized");
+        require(wards[msg.sender] == 1, "RwaInputConduit3/not-authorized");
         _;
     }
 

--- a/src/conduits/RwaOutputConduit2.t.sol
+++ b/src/conduits/RwaOutputConduit2.t.sol
@@ -1,0 +1,313 @@
+// SPDX-FileCopyrightText: © 2022 Dai Foundation <www.daifoundation.org>
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+pragma solidity 0.6.12;
+
+import "forge-std/Test.sol";
+import "ds-token/token.sol";
+import "ds-math/math.sol";
+import "ds-value/value.sol";
+
+import {Vat} from "dss/vat.sol";
+import {Jug} from "dss/jug.sol";
+import {Spotter} from "dss/spot.sol";
+import {Vow} from "dss/vow.sol";
+import {GemJoin, DaiJoin} from "dss/join.sol";
+import {Dai} from "dss/dai.sol";
+
+import {RwaOutputConduit2} from "./RwaOutputConduit2.sol";
+
+contract RwaOutputConduit2Test is Test, DSMath {
+    address me = address(this);
+
+    Dai dai = new Dai(0);
+    RwaOutputConduit2 outputConduit = new RwaOutputConduit2(address(dai));
+
+    function setUp() public {
+        outputConduit.mate(me);
+        outputConduit.hope(me);
+        outputConduit.pick(me);
+    }
+
+    function testSetWardAndEmitRelyOnDeploy() public {
+        vm.expectEmit(true, false, false, false);
+        emit Rely(me);
+
+        RwaOutputConduit2 c = new RwaOutputConduit2(address(dai));
+
+        assertEq(c.wards(me), 1);
+    }
+
+    function testRevertOnPushWhenToAddressNotPicked() public {
+        RwaOutputConduit2 c = new RwaOutputConduit2(address(dai));
+
+        c.mate(me);
+        c.hope(me);
+
+        vm.expectRevert("RwaOutputConduit2/to-not-picked");
+        c.push();
+    }
+
+    function testRelyDeny() public {
+        assertEq(outputConduit.wards(address(1)), 0);
+
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Rely(address(1));
+
+        outputConduit.rely(address(1));
+
+        assertEq(outputConduit.wards(address(1)), 1);
+
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Deny(address(1));
+
+        outputConduit.deny(address(1));
+
+        assertEq(outputConduit.wards(address(1)), 0);
+
+        // Test make it permissionless
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Rely(address(0));
+
+        outputConduit.rely(address(0));
+
+        assertEq(outputConduit.wards(address(0)), 1);
+
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Deny(address(0));
+
+        outputConduit.deny(address(0));
+
+        assertEq(outputConduit.wards(address(0)), 0);
+    }
+
+    function testMateHate() public {
+        assertEq(outputConduit.may(address(1)), 0);
+
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Mate(address(1));
+
+        outputConduit.mate(address(1));
+
+        assertEq(outputConduit.may(address(1)), 1);
+
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Hate(address(1));
+
+        outputConduit.hate(address(1));
+
+        assertEq(outputConduit.may(address(1)), 0);
+
+        assertEq(outputConduit.may(address(1)), 0);
+
+        // Test make it permissionless
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Mate(address(0));
+
+        outputConduit.mate(address(0));
+
+        assertEq(outputConduit.may(address(0)), 1);
+
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Hate(address(0));
+
+        outputConduit.hate(address(0));
+
+        assertEq(outputConduit.may(address(0)), 0);
+    }
+
+    function testHopeNope() public {
+        assertEq(outputConduit.can(address(1)), 0);
+
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Hope(address(1));
+
+        outputConduit.hope(address(1));
+
+        assertEq(outputConduit.can(address(1)), 1);
+
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Nope(address(1));
+
+        outputConduit.nope(address(1));
+
+        assertEq(outputConduit.can(address(1)), 0);
+
+        // Test make it permissionless
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Hope(address(0));
+
+        outputConduit.hope(address(0));
+
+        assertEq(outputConduit.can(address(0)), 1);
+
+        // --------------------
+        vm.expectEmit(true, false, false, false);
+        emit Nope(address(0));
+
+        outputConduit.nope(address(0));
+
+        assertEq(outputConduit.can(address(0)), 0);
+    }
+
+    function testFuzzRevertOnUnauthorizedMethods(address sender) public {
+        vm.startPrank(sender);
+
+        vm.expectRevert("RwaOutputConduit2/not-authorized");
+        outputConduit.rely(sender);
+
+        vm.expectRevert("RwaOutputConduit2/not-authorized");
+        outputConduit.deny(sender);
+
+        vm.expectRevert("RwaOutputConduit2/not-authorized");
+        outputConduit.hope(sender);
+
+        vm.expectRevert("RwaOutputConduit2/not-authorized");
+        outputConduit.nope(sender);
+
+        vm.expectRevert("RwaOutputConduit2/not-authorized");
+        outputConduit.hate(sender);
+
+        vm.expectRevert("RwaOutputConduit2/not-authorized");
+        outputConduit.mate(sender);
+    }
+
+    function testFuzzRevertOnNotMateMethods(address sender) public {
+        vm.expectRevert("RwaOutputConduit2/not-mate");
+
+        vm.prank(sender);
+        outputConduit.push();
+    }
+
+    function testFuzzRevertOnNotOperatorMethods(address sender) public {
+        vm.expectRevert("RwaOutputConduit2/not-operator");
+
+        vm.prank(sender);
+        outputConduit.pick(sender);
+    }
+
+    function testFuzzMakeMethodsPermissionless(address sender) public {
+        vm.assume(sender != address(0));
+
+        outputConduit.rely(address(0));
+        outputConduit.hope(address(0));
+        outputConduit.may(address(0));
+
+        vm.startPrank(sender);
+
+        outputConduit.rely(sender);
+        assertEq(outputConduit.wards(sender), 1);
+
+        outputConduit.hope(sender);
+        assertEq(outputConduit.can(sender), 1);
+
+        outputConduit.mate(sender);
+        assertEq(outputConduit.may(sender), 1);
+
+        outputConduit.hate(sender);
+        assertEq(outputConduit.may(sender), 0);
+
+        outputConduit.nope(sender);
+        assertEq(outputConduit.can(sender), 0);
+
+        outputConduit.deny(sender);
+        assertEq(outputConduit.wards(sender), 0);
+    }
+
+    function testPick() public {
+        address who = vm.addr(2);
+
+        vm.expectEmit(true, false, false, false);
+        emit Pick(who);
+        outputConduit.pick(who);
+        assertEq(outputConduit.to(), who);
+
+        // pick zero address
+        vm.expectEmit(true, false, false, false);
+        emit Pick(address(0));
+
+        outputConduit.pick(address(0));
+        assertEq(outputConduit.to(), address(0));
+    }
+
+    function testPush() public {
+        dai.mint(me, 1_000 * WAD);
+
+        assertEq(outputConduit.to(), me);
+        assertEq(dai.balanceOf(address(me)), 1_000 * WAD);
+
+        dai.transfer(address(outputConduit), 500 * WAD);
+
+        assertEq(dai.balanceOf(me), 500 * WAD);
+        assertEq(dai.balanceOf(address(outputConduit)), 500 * WAD);
+
+        vm.expectEmit(true, false, false, true);
+        emit Push(me, 500 * WAD);
+
+        outputConduit.push();
+
+        assertEq(outputConduit.to(), address(0));
+        assertEq(dai.balanceOf(address(outputConduit)), 0);
+        assertEq(dai.balanceOf(me), 1_000 * WAD);
+    }
+
+    function testFuzzPermissionlessPush(address sender) public {
+        vm.assume(sender != me);
+
+        dai.mint(me, 1_000 * WAD);
+
+        assertEq(outputConduit.to(), me);
+        assertEq(dai.balanceOf(address(me)), 1_000 * WAD);
+
+        dai.transfer(address(outputConduit), 500 * WAD);
+
+        assertEq(dai.balanceOf(me), 500 * WAD);
+        assertEq(dai.balanceOf(address(outputConduit)), 500 * WAD);
+
+        outputConduit.mate(address(0));
+
+        vm.expectEmit(true, false, false, true);
+        emit Push(me, 500 * WAD);
+
+        vm.prank(sender);
+        outputConduit.push();
+
+        assertEq(outputConduit.to(), address(0));
+        assertEq(dai.balanceOf(address(outputConduit)), 0);
+        assertEq(dai.balanceOf(me), 1_000 * WAD);
+    }
+
+    event Rely(address indexed usr);
+    event Deny(address indexed usr);
+    event Hope(address indexed usr);
+    event Nope(address indexed usr);
+    event Mate(address indexed usr);
+    event Hate(address indexed usr);
+    event Push(address indexed to, uint256 wad);
+    event Pick(address indexed who);
+}

--- a/src/conduits/RwaOutputConduit3.sol
+++ b/src/conduits/RwaOutputConduit3.sol
@@ -135,7 +135,7 @@ contract RwaOutputConduit3 {
     event Yank(address indexed token, address indexed usr, uint256 amt);
 
     modifier auth() {
-        require(wards[msg.sender] == 1 || wards[address(0)] == 1, "RwaOutputConduit3/not-authorized");
+        require(wards[msg.sender] == 1, "RwaOutputConduit3/not-authorized");
         _;
     }
 

--- a/src/conduits/RwaOutputConduit3.t.sol
+++ b/src/conduits/RwaOutputConduit3.t.sol
@@ -29,11 +29,11 @@ import {Vow} from "dss/vow.sol";
 import {GemJoin, DaiJoin} from "dss/join.sol";
 import {Dai} from "dss/dai.sol";
 
-import {RwaOutputConduit3} from "./RwaOutputConduit3.sol";
-
 import {DssPsm} from "dss-psm/psm.sol";
 import {AuthGemJoin5} from "dss-psm/join-5-auth.sol";
 import {AuthGemJoin} from "dss-psm/join-auth.sol";
+
+import {RwaOutputConduit3} from "./RwaOutputConduit3.sol";
 
 contract RwaOutputConduit3Test is Test, DSMath {
     address me;


### PR DESCRIPTION
Granting a role to `address(0)` makes the methods exclusive to that role permissionless.

This is an alternative to #25.