### PR TITLE
Deprecate MIP21 Terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Equipment for MIP21: Off-chain Asset Backed Lending in MakerDAO
+# Equipment for Off-chain Asset Backed Lending in MakerDAO
 
 ## Components
 
@@ -6,10 +6,10 @@
 - `RwaUrn`: facilitates borrowing of DAI, delivering to a designated account.
 - `RwaUrn2`: variation of `RwaUrn` that allows authorized parties to flush out any outstanding DAI at any moment.
 - `RwaOutputConduit`: disburses DAI.
-- `RwaOutputConduit2`: variation of `RwaOutputConduit` with an whitelist to control permissions to disburse DAI.
+- `RwaOutputConduit2`: variation of `RwaOutputConduit` with a whitelist to control permissions to disburse DAI.
 - `RwaSwapOutputConduit`: variation of `RwaOutputConduit` for swapping DAI to GEM through a PSM.
 - `RwaInputConduit`: repays DAI.
-- `RwaInputConduit2`: variation of `RwaInputConduit` with an whitelist to control permissions to repay DAI.
+- `RwaInputConduit2`: variation of `RwaInputConduit` with a whitelist to control permissions to repay DAI.
 - `RwaSwapInputConduit`: variation of `RwaInputConduit` for swapping GEM to DAI through a PSM.
 - `RwaSwapInputConduit2`: variation of `RwaSwapInputConduit` with a permissionless `push`.
 - `RwaToken`: represents the RWA collateral in the system.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
-  "name": "socgen-ofh-onboarding-prototype",
+  "name": "rwa-toolkit",
   "version": "1.0.0",
   "main": "index.js",
-  "repository": "git@github.com:ClioFinance/socgen-ofh-onboarding-prototype.git",
-  "author": "Henrique Barcelos <hbarcelos909@gmail.com>",
-  "license": "MIT",
+  "repository": "git@github.com:makerdao/rwa-toolkit.git",
+  "license": "AGPL-3.0-or-later",
   "scripts": {
     "prepare": "husky install",
     "prepublishOnly": "copyfiles -u 1 \"./src/**/*.sol\" ./",


### PR DESCRIPTION
Deprecates MIP21 terminology as the Endgame Spec is deprecating all previous MIPS.

Moving forward, we will refer to deals following this structure simply as RWA deals.
